### PR TITLE
Doc updates to address issues 46 & 47

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -68,13 +68,13 @@ If you've got an idea for a new feature and you feel it fits the vision, file
 an issue and we can discuss it.
 
 Make sure any feature request you make fits the
-[INVEST](http://en.wikipedia.org/wiki/INVEST_(mnemonic) mnemonic.
+[INVEST](http://en.wikipedia.org/wiki/INVEST_(mnemonic)) mnemonic.
 
 ## <a name="pull-requests"></a>Pull Requests
 A well written pull request is a huge piece of the success of any open source project.
 Please make sure to take the time to think out the request and document/comment well.
 A good pull request should be the smallest successful feature, akin to the
-[INVEST](http://en.wikipedia.org/wiki/INVEST_(mnemonic) mnemonic used in scrum.
+[INVEST](http://en.wikipedia.org/wiki/INVEST_(mnemonic)) mnemonic used in scrum.
 
 Make sure if you're not a project member and just getting started that you have a
 related issue for your Pull Request and that a project owner approves the work

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -84,7 +84,7 @@ Whenever you want to run the existing integration tests, you can execute the
 following command in your bash shell.
 
 ```bash
-  phpunit --bootstrap test/phpunit/bootstrap.php test/phpunit/Integration
+  phpunit --bootstrap test/phpunit/bootstrap.php --group Integration test/phpunit/
 ```
 
 ## Unit Tests
@@ -108,5 +108,5 @@ Whenever you want to run the existing unit tests, you can execute the
 following command in your bash shell.
 
 ```bash
-  phpunit --bootstrap test/phpunit/bootstrap.php test/phpunit/Mock
+  phpunit --bootstrap test/phpunit/bootstrap.php --group Mock test/phpunit/
 ```


### PR DESCRIPTION
- **Issue 46:** Updated the markdown syntax for the INVEST links in the contributing doc to have the link render correctly.
- **Issue 47:** Updated the examples for running integration and unit tests to use the `--group` syntax for phpunit and removed the references to directories that no longer exist.
